### PR TITLE
add 3cb8a74 curl commit to test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,7 @@ jobs:
           [
             c4e6968,
             842f73d,
+            3cb8a74,
             master
           ]
         testApp:


### PR DESCRIPTION
From the curl commit history, the HTTP/2 post issue was fixed by the
3cb8a74 commit.

Signed-off-by: Inho Oh <webispy@gmail.com>